### PR TITLE
Made "SearchEndpoint" configurable

### DIFF
--- a/StarWars5e.Api/Startup.cs
+++ b/StarWars5e.Api/Startup.cs
@@ -86,12 +86,13 @@ namespace StarWars5e.Api
                     });
             });
 
+            var searchEndpoint = Configuration["SearchEndpoint"] ?? "https://sw5esearch.search.windows.net";
             var tableStorage = new AzureTableStorage(Configuration["StorageAccountConnectionString"]);
             var cloudStorageAccount = CloudStorageAccount.Parse(Configuration["StorageAccountConnectionString"]);
             var cloudTableClient = cloudStorageAccount.CreateCloudTableClient();
             var cloudBlobClient = new BlobServiceClient(Configuration["StorageAccountConnectionString"]);
-            var searchIndexClient = new SearchIndexClient(new Uri("https://sw5esearch.search.windows.net"), new AzureKeyCredential(Configuration["SearchKey"]));
-            var searchClient = new SearchClient(new Uri("https://sw5esearch.search.windows.net"), "searchterms-index", new AzureKeyCredential(Configuration["SearchKey"]));
+            var searchIndexClient = new SearchIndexClient(new Uri(searchEndpoint), new AzureKeyCredential(Configuration["SearchKey"]));
+            var searchClient = new SearchClient(new Uri(searchEndpoint), "searchterms-index", new AzureKeyCredential(Configuration["SearchKey"]));
 
             services.AddSingleton<IAzureTableStorage>(tableStorage);
 

--- a/StarWars5e.Parser/Program.cs
+++ b/StarWars5e.Parser/Program.cs
@@ -62,9 +62,10 @@ namespace StarWars5e.Parser
 
             if (!string.IsNullOrWhiteSpace(config["SearchKey"]))
             {
-                var searchIndexClient = new SearchIndexClient(new Uri("https://sw5esearch.search.windows.net"),
+                var searchEndpoint = config["SearchEndpoint"] ?? "https://sw5esearch.search.windows.net";
+                var searchIndexClient = new SearchIndexClient(new Uri(searchEndpoint),
                     new AzureKeyCredential(config["SearchKey"]));
-                var searchIndexerClient = new SearchIndexerClient(new Uri("https://sw5esearch.search.windows.net"),
+                var searchIndexerClient = new SearchIndexerClient(new Uri(searchEndpoint),
                     new AzureKeyCredential(config["SearchKey"]));
 
                 serviceProvider.AddSingleton(searchIndexClient);


### PR DESCRIPTION
When setting up my own Search/TableStorage I noticed that the SearchEndpoint is hardcoded. I changed it to configurable.